### PR TITLE
Make Themer theme the user list font

### DIFF
--- a/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Patches.kt
+++ b/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Patches.kt
@@ -35,6 +35,7 @@ import com.aliucord.wrappers.messages.AttachmentWrapper.Companion.url
 import com.discord.app.*
 import com.discord.databinding.WidgetChatListAdapterItemEmbedBinding
 import com.discord.utilities.color.ColorCompat
+import com.discord.views.UsernameView
 import com.discord.widgets.chat.list.actions.WidgetChatListActions
 import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemAttachment
 import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemEmbed
@@ -237,6 +238,16 @@ private fun PatcherAPI.patchGetFont() {
             }
         }
     })
+
+    // UsernameView somehow doesn't follow the fonts loaded from
+    // the ResourcesCompat hook, so it must be hooked separately
+    patch(UsernameView::class.java.getDeclaredMethod("setUsernameColor", Int::class.javaPrimitiveType),
+        Hook { param ->
+            with (param.thisObject as UsernameView) {
+                // Target the SimpleDraweeSpanTextView found in the ViewBinding used by UsernameView
+                this.j.c.typeface = ResourceManager.getFontForId(Constants.Fonts.whitney_medium) ?: this.j.c.typeface
+            }
+        })
 }
 
 private fun PatcherAPI.patchOpenRawResource() {


### PR DESCRIPTION
When using Themer to load custom fonts, the names found in the user list (right side bar) for some reason remain unthemed; the default font will load over the font defined by the theme itself.

This PR should address that in a (hopefully) clean way. From my test, there doesn't seem to be any regression visible from this change, but I've only done the rudimentary just to make sure nothing catches on fire.