### PR TITLE
fix(Themer): fix colours not theming on new Android versions

### DIFF
--- a/Themer/build.gradle.kts
+++ b/Themer/build.gradle.kts
@@ -1,8 +1,11 @@
-version = "3.6.2"
+version = "3.6.3"
 description = "Apply custom themes to your Discord"
 
 aliucord.changelog.set(
     """
+    # 3.6.3
+    * Fix color theming for newer android versions
+
     # 3.6.2
     * Now prompts to switch to dark mode if using light/pureEvil theme
     

--- a/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Patches.kt
+++ b/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Patches.kt
@@ -55,6 +55,7 @@ fun addPatches(patcher: PatcherAPI) {
         if (Themer.mSettings.customSounds) patchOpenRawResource()
 
         patchGetColor()
+        patchLoadDrawable()
         patchSetColor()
         patchColorStateLists()
         tintDrawables()
@@ -234,6 +235,24 @@ private fun PatcherAPI.patchGetFont() {
             }
         }
     })
+}
+
+private fun PatcherAPI.patchLoadDrawable() {
+    patch(
+        Resources::class.java.getDeclaredMethod(
+            "loadDrawable",
+            TypedValue::class.java,
+            Int::class.javaPrimitiveType!!,
+            Int::class.javaPrimitiveType!!,
+            Resources.Theme::class.java
+        ), PreHook { param ->
+            val value = param.args[0] as TypedValue
+            if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                ResourceManager.getColorReplacement(value.data)?.let {
+                    value.data = it
+                }
+            }
+        })
 }
 
 private fun PatcherAPI.patchOpenRawResource() {

--- a/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Patches.kt
+++ b/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Patches.kt
@@ -238,21 +238,31 @@ private fun PatcherAPI.patchGetFont() {
 }
 
 private fun PatcherAPI.patchLoadDrawable() {
-    patch(
+    val target = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         Resources::class.java.getDeclaredMethod(
             "loadDrawable",
             TypedValue::class.java,
             Int::class.javaPrimitiveType!!,
             Int::class.javaPrimitiveType!!,
             Resources.Theme::class.java
-        ), PreHook { param ->
-            val value = param.args[0] as TypedValue
-            if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
-                ResourceManager.getColorReplacement(value.data)?.let {
-                    value.data = it
-                }
+        )
+    } else {
+        Resources::class.java.getDeclaredMethod(
+            "loadDrawable",
+            TypedValue::class.java,
+            Int::class.javaPrimitiveType!!,
+            Resources.Theme::class.java
+        )
+    }
+
+    patch(target, PreHook { param ->
+        val value = param.args[0] as TypedValue
+        if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+            ResourceManager.getColorReplacement(value.data)?.let {
+                value.data = it
             }
-        })
+        }
+    })
 }
 
 private fun PatcherAPI.patchOpenRawResource() {


### PR DESCRIPTION
On newer Android versions, some `ColorDrawable`s are cached too early, or preloaded such that Themer can't hook `setColor` for them. One such noticable colour is the main background.

This PR adds a new patch for `loadDrawable` and sets the colour there. `loadDrawable` normally finds the `ColorDrawable` in cache, or if it doesn't exist would eventually lead to `ColorDrawable.setColor`.