### PR TITLE
Themer: fix more unthemed elements

### DIFF
--- a/Themer/build.gradle.kts
+++ b/Themer/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Apply custom themes to your Discord"
 aliucord.changelog.set(
     """
     # 3.6.4
-    * Fix color theming for some elements like user profile header and chatbox.
+    * Fix color theming for some elements like user profile header and chatbox
 
     # 3.6.3
     * Fix color theming for newer android versions

--- a/Themer/build.gradle.kts
+++ b/Themer/build.gradle.kts
@@ -1,8 +1,11 @@
-version = "3.6.3"
+version = "3.6.4"
 description = "Apply custom themes to your Discord"
 
 aliucord.changelog.set(
     """
+    # 3.6.4
+    * Fix color theming for some elements like user profile header and chatbox.
+
     # 3.6.3
     * Fix color theming for newer android versions
 

--- a/Themer/build.gradle.kts
+++ b/Themer/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Apply custom themes to your Discord"
 aliucord.changelog.set(
     """
     # 3.6.4
-    * Fix color theming for some elements like user profile header and chatbox
+    * Fix colour theming for some elements like user profile header and chatbox
 
     # 3.6.3
     * Fix color theming for newer android versions

--- a/Themer/build.gradle.kts
+++ b/Themer/build.gradle.kts
@@ -7,7 +7,7 @@ aliucord.changelog.set(
     * Fix colour theming for some elements like user profile header and chatbox
 
     # 3.6.3
-    * Fix color theming for newer android versions
+    * Fix colour theming for newer android versions
 
     # 3.6.2
     * Now prompts to switch to dark mode if using light/pureEvil theme


### PR DESCRIPTION
Some of the hooked methods are still inlined despite Aliucord's efforts to prevent it. This PR deoptimises a few callers that caused certain elements to not be themed, such as the chat input and user profile header.