### PR TITLE
fix: resolve Themer crash and pin build dependencies for legacy compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src
         chmod +x gradlew
-        ./gradlew make generateUpdaterJson
+        ./gradlew make generateUpdaterJson -q
         cp **/build/*.zip $GITHUB_WORKSPACE/builds
         cp build/updater.json $GITHUB_WORKSPACE/builds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Themer/build.gradle.kts
+++ b/Themer/build.gradle.kts
@@ -1,8 +1,11 @@
-version = "3.6.4"
+version = "3.6.5"
 description = "Apply custom themes to your Discord"
 
 aliucord.changelog.set(
     """
+    # 3.6.5
+    * Fix theme editor crashing when themes use Android 12 Material You (system_) dynamic colors, hexadecimal strings (#FF..., 0xFF...), or color names
+    
     # 3.6.4
     * Fix colour theming for some elements like user profile header and chatbox
 

--- a/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/ThemeLoader.kt
+++ b/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/ThemeLoader.kt
@@ -131,22 +131,7 @@ object ThemeLoader {
     }
 
 
-    private fun parseColor(json: JSONObject, key: String): Int {
-        val v = json.getString(key)
-        return if (v.startsWith("system_")) {
-            if (Build.VERSION.SDK_INT < 31)
-                throw UnsupportedOperationException("system_ colours are only supported on Android 12.")
-
-            try {
-                ContextCompat.getColor(
-                    Utils.appContext,
-                    ReflectUtils.getField(android.R.color::class.java, null, v) as Int
-                )
-            } catch (th: Throwable) {
-                throw IllegalArgumentException("No such color: $v")
-            }
-        } else v.toInt()
-    }
+    private fun parseColor(json: JSONObject, key: String): Int = json.parseColor(key)
 
     fun loadThemes(shouldLoad: Boolean) {
         themes.clear()

--- a/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Util.kt
+++ b/Themer/src/main/kotlin/dev/vendicated/aliucordplugs/themer/Util.kt
@@ -10,7 +10,12 @@
 
 package dev.vendicated.aliucordplugs.themer
 
+import android.graphics.Color
+import android.os.Build
+import androidx.core.content.ContextCompat
+import com.aliucord.Utils
 import com.aliucord.api.SettingsAPI
+import com.aliucord.utils.ReflectUtils
 import dev.vendicated.aliucordplugs.themer.settings.editor.tabs.color.ColorTuple
 import org.json.JSONObject
 
@@ -30,9 +35,51 @@ var SettingsAPI.fontHookCausedCrash
     get() = getBool("fontHookCausedCrash", false)
     set(v) = setBool("fontHookCausedCrash", v)
 
+fun JSONObject.parseColor(key: String): Int {
+    val v = getString(key)
+    return if (v.startsWith("system_")) {
+        if (Build.VERSION.SDK_INT < 31)
+            throw UnsupportedOperationException("system_ colours are only supported on Android 12.")
+
+        try {
+            ContextCompat.getColor(
+                Utils.appContext,
+                ReflectUtils.getField(android.R.color::class.java, null, v) as Int
+            )
+        } catch (th: Throwable) {
+            throw IllegalArgumentException("No such color: $v", th)
+        }
+    } else {
+        try {
+            v.toInt()
+        } catch (e: NumberFormatException) {
+            try {
+                if (v.startsWith("0x", true)) {
+                    v.substring(2).toLong(16).toInt()
+                } else if (v.startsWith("#")) {
+                    Color.parseColor(v)
+                } else {
+                    v.toLong().toInt()
+                }
+            } catch (th: Throwable) {
+                try {
+                    Color.parseColor(v)
+                } catch (ignored: Throwable) {
+                    throw IllegalArgumentException("No such color or invalid format: $v", th)
+                }
+            }
+        }
+    }
+}
+
 fun JSONObject.toColorArray() = ArrayList<ColorTuple>().apply {
     keys().forEach {
-        add(ColorTuple(it, getInt(it)))
+        try {
+            add(ColorTuple(it, parseColor(it)))
+        } catch (th: Throwable) {
+            logger.error("Failed to parse color for key $it", th)
+            add(ColorTuple(it, Color.MAGENTA))
+        }
     }
     sortBy { it.name }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.0.4")
-        classpath("com.aliucord:gradle:main-SNAPSHOT") {
+        classpath("com.aliucord:gradle:bbcd8a8") {
             exclude("com.github.js6pak", "jadb")
         }
         classpath("com.aliucord:jadb:1.2.1-SNAPSHOT")
@@ -72,8 +72,8 @@ subprojects {
         val implementation by configurations
         val api by configurations
 
-        discord("com.discord:discord:aliucord-SNAPSHOT")
-        implementation("com.aliucord:Aliucord:main-SNAPSHOT")
+        discord("com.discord:discord:126021")
+        implementation("com.aliucord:Aliucord:2.1.1")
         // implementation("com.aliucord:Aliucord:unspecified")
 
         implementation("androidx.appcompat:appcompat:1.4.1")


### PR DESCRIPTION
- Update Themer to 3.6.5 to fix editor crashes with Android 12 dynamic colors, hex strings, or color names
- Pin Aliucord and Gradle dependencies to fixed versions so existing plugins build without needing updates (thanks Archimedes9500)